### PR TITLE
chore: upgrade the patroni chart that the new kc chart uses

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 name: sso-keycloak
-version: 1.14.2
-appVersion: 7.6.5-build.8
+version: 1.14.3
+appVersion: 7.6.5-build.28
 description: Open Source Identity and Access Management For Modern Applications and Services
 dependencies:
   - name: patroni
-    version: 1.5.1
+    version: 1.6.0
     repository: https://bcgov.github.io/sso-helm-charts
     tags:
       - patroni-enabled


### PR DESCRIPTION
This chart was deployed from local to sand dev gold.  There was no interruption to the keycloak deployment, the tsc's and services were installed.