### PR TITLE
chore: regress patroni version so github action not blocked

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -5,7 +5,7 @@ appVersion: 7.6.5-build.29
 description: Open Source Identity and Access Management For Modern Applications and Services
 dependencies:
   - name: patroni
-    version: 1.5.2
+    version: 1.5.1
     repository: https://bcgov.github.io/sso-helm-charts
     tags:
       - patroni-enabled


### PR DESCRIPTION
This PR is needed because the github action is blocking the builds