### PR TITLE
fix: updates to handle clustering error

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sso-keycloak
-version: 1.14.3
-appVersion: 7.6.5-build.29
+version: 1.14.4
+appVersion: 7.6.25-build.1
 description: Open Source Identity and Access Management For Modern Applications and Services
 dependencies:
   - name: patroni

--- a/charts/keycloak/templates/service-ping.yaml
+++ b/charts/keycloak/templates/service-ping.yaml
@@ -6,7 +6,6 @@ metadata:
   labels: {{ include "sso-keycloak.labels" . | nindent 4 }}
   annotations:
     description: "The JGroups ping port for clustering."
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
     {{- if .Values.tls.enabled }}
     # see https://miminar.fedorapeople.org/_preview/openshift-enterprise/registry-redeploy/dev_guide/secrets.html#service-serving-certificate-secrets
     service.alpha.openshift.io/serving-cert-secret-name: {{ include "sso-keycloak.fullname" . }}-x509-jgroups
@@ -19,4 +18,5 @@ spec:
       targetPort: ping
       protocol: TCP
   selector: {{ include "sso-keycloak.selectorLabels" . | nindent 4 }}
+  publishNotReadyAddresses: true
 {{- end }}


### PR DESCRIPTION
The tolerate-unready-endpoints was an annotation that was replaced by `service.spec.publishNotReadyAddresses` - a `spec.field` - that's a core difference.
Therefore, `tolerate-unready-endpoints` [is no longer valid on OpenShift 4.8 and above] (https://github.com/kubernetes/kubernetes/pull/63742). Instead, service.spec.publishNotReadyAddresses must be used.

Reference: https://access.redhat.com/solutions/6699001