### PR TITLE
feat: add an optional pdb to keycloak

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sso-keycloak
-version: 1.14.4
-appVersion: 7.6.25-build.1
+version: 1.15.0
+appVersion: 7.6.39-build.1
 description: Open Source Identity and Access Management For Modern Applications and Services
 dependencies:
   - name: patroni

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -67,6 +67,9 @@ The following table lists the configurable parameters of the Keycloak chart and 
 | `tolerations`                      | toleration settings                                              | `[]`                                                                                       |
 | `affinity`                         | affinity settings                                                | `{}`                                                                                       |
 | `affinityTemplate`                 | a template string to use to generate the affinity settings       |                                                                                            |
+| `podDisruptionBudget.enabled`                 | does keycloak have a pod disruption budget | false  |
+| `podDisruptionBudget.minAvailable`            | min number of keycloak pods available      |        |
+| `podDisruptionBudget.maxUnavailable`          | max number of keycloak pods unavailable    |        |
 | `maintenancePage.enabled`          | deploy maintenance page app                                      | `false`                                                                                    |
 | `maintenancePage.active`           | forward incoming traffic to maintenance page app                 | `false`                                                                                    |
 | `maintenancePage.replicaCount`     | number of maintenance app pods to create                         | `1`                                                                                        |

--- a/charts/keycloak/templates/poddisruptionbudget.yaml
+++ b/charts/keycloak/templates/poddisruptionbudget.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "sso-keycloak.fullname" . }}-pdb
+  labels: {{ include "sso-keycloak.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: 0
+  {{- end }}
+  selector:
+    matchLabels: {{ include "sso-keycloak.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -117,6 +117,11 @@ affinityTemplate: |
         labelSelector:
           matchLabels: {{ include "sso-keycloak.selectorLabels" . | nindent 10 }}
 
+podDisruptionBudget:
+  enabled: false
+  minAvailable:
+  maxUnavailable:
+
 patroni:
   replicaCount: 3
   # RH-SSO v7.5-9 is not tested with PostgreSQL 14


### PR DESCRIPTION
adds new backwards compatible optional PDB to the keycloak helm chart