### PR TITLE
Stateful set

### DIFF
--- a/charts/keycloak/templates/deployment.yaml
+++ b/charts/keycloak/templates/deployment.yaml
@@ -55,15 +55,6 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           command: ["/bin/sh", "-c"]
-          # args:
-          #   - |
-          #     base_config={{ $configDir }}-provisioning/standalone-openshift.xml
-          #     target_config={{ $configDir }}/standalone-openshift.xml
-          #     if [[ -f "$base_config" ]]; then
-          #         rm "$target_config"
-          #         cp "$base_config" "$target_config"
-          #     fi;
-          #     /opt/keycloak/bin/kc.sh;
           args:
             - |
               /opt/keycloak/bin/kc.sh start --optimized
@@ -77,7 +68,7 @@ spec:
               - timeout 60 /opt/eap/bin/livenessProbe.sh
           {{- else }}
             httpGet:
-              path: /auth/health/live
+              path: /health/live
               port: 8080
           {{- end -}}
           {{ (omit .Values.livenessProbe "enabled" "verification") | toYaml | nindent 12 }}
@@ -93,7 +84,7 @@ spec:
               - timeout 60 /opt/eap/bin/readinessProbe.sh
           {{- else }}
             httpGet:
-              path: /auth/health/ready
+              path: /health/ready
               port: 8080
           {{- end -}}
           {{ (omit .Values.readinessProbe "enabled" "verification") | toYaml | nindent 12 }}
@@ -107,9 +98,6 @@ spec:
               protocol: TCP
             - containerPort: 8443
               name: https
-              protocol: TCP
-            - containerPort: 8888
-              name: ping
               protocol: TCP
           env:
             # Postgres Service Endpoint
@@ -154,33 +142,8 @@ spec:
               value: {{ .Values.postgres.poolSize.min | quote }}
             - name: DB_MAX_POOL_SIZE
               value: {{ .Values.postgres.poolSize.max | quote }}
-            # JGroups Cluster
-            - name: JGROUPS_CLUSTER_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "sso-keycloak.fullname" . }}-jgroups
-                  key: cluster-password
-            # Additional server startup options (extension of JAVA_OPTS)
             - name: JAVA_OPTS_APPEND
               value: {{ .Values.additionalServerOptions }}
-            - name: X509_CA_BUNDLE
-              value: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
-            # https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.4/html/getting_started_with_jboss_eap_for_openshift_container_platform/reference_information#configuring_dns_ping
-            {{- if .Values.pingService.enabled }}
-            - name: JGROUPS_PING_PROTOCOL
-              value: dns.DNS_PING
-            - name: OPENSHIFT_DNS_PING_SERVICE_NAME
-              value: {{ include "sso-keycloak.fullname" . }}-ping
-            - name: OPENSHIFT_DNS_PING_SERVICE_PORT
-              value: {{ .Values.pingService.port | quote }}
-            {{- end }}
-            # Other environments
-            - name: DB_JNDI
-              value: java:jboss/datasources/KeycloakDS
-            - name: DB_SERVICE_PREFIX_MAPPING
-              value: db-postgresql=DB
-            - name: TX_DATABASE_PREFIX_MAPPING
-              value: db-postgresql=DB
             - name: TZ
               value: America/Vancouver
             - name: KC_HOSTNAME_STRICT_HTTPS

--- a/charts/keycloak/templates/deployment.yaml
+++ b/charts/keycloak/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $configDir := "/opt/eap/standalone/configuration" -}}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "sso-keycloak.fullname" . }}
   labels: {{ include "sso-keycloak.labels" . | nindent 4 }}
@@ -14,6 +14,7 @@ spec:
   minReadySeconds: 30 # The minimum number of seconds for which a newly created Pod should be ready
   selector:
     matchLabels: {{ include "sso-keycloak.selectorLabels" . | nindent 6 }}
+  serviceName: {{ include "sso-keycloak.fullname" . }}-ping
   template:
     metadata:
       {{- if .Values.configuration.enabled }}
@@ -65,7 +66,7 @@ spec:
           #     /opt/keycloak/bin/kc.sh;
           args:
             - |
-              /opt/keycloak/bin/kc.sh start
+              /opt/keycloak/bin/kc.sh start --optimized
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
           {{- if eq .Values.livenessProbe.verification "script"}}
@@ -123,7 +124,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.postgres.credentials.secret }}
                   key: {{ .Values.postgres.credentials.usernameKey }}
-              {{- else -}}
+              {{- else }}
               value: {{ .Values.postgres.credentials.username }}
               {{- end }}
             - name: KC_DB_PASSWORD
@@ -132,7 +133,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.postgres.credentials.secret }}
                   key: {{ .Values.postgres.credentials.passwordKey }}
-              {{- else -}}
+              {{- else }}
               value: {{ .Values.postgres.credentials.password }}
               {{- end }}
             - name: KC_DB_URL_DATABASE

--- a/charts/keycloak/templates/service-ping.yaml
+++ b/charts/keycloak/templates/service-ping.yaml
@@ -1,11 +1,10 @@
-{{- if .Values.pingService.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "sso-keycloak.fullname" . }}-ping
   labels: {{ include "sso-keycloak.labels" . | nindent 4 }}
   annotations:
-    description: "The JGroups ping port for clustering."
+    description: "The headless service for the keycloak stateful set."
     {{- if .Values.tls.enabled }}
     # see https://miminar.fedorapeople.org/_preview/openshift-enterprise/registry-redeploy/dev_guide/secrets.html#service-serving-certificate-secrets
     service.alpha.openshift.io/serving-cert-secret-name: {{ include "sso-keycloak.fullname" . }}-x509-jgroups
@@ -13,10 +12,16 @@ metadata:
 spec:
   clusterIP: None
   ports:
-    - port: {{ .Values.pingService.port }}
-      name: ping
-      targetPort: ping
+    {{- if .Values.tls.enabled }}
+    - name: https
+      port: {{ .Values.service.port }}
       protocol: TCP
+      targetPort: https
+    {{- else }}
+    - name: http 
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+    {{- end }}
   selector: {{ include "sso-keycloak.selectorLabels" . | nindent 4 }}
   publishNotReadyAddresses: true
-{{- end }}

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -1,8 +1,8 @@
-replicaCount: 2
+replicaCount: 1
 
 image:
   repository: ghcr.io/bcgov/sso
-  tag:  24.0.8-build.1
+  tag:  24.0.5-build.1
   pullPolicy: Always
 
 project: sso-keycloak
@@ -19,7 +19,7 @@ networkPolicies:
 
 service:
   type: ClusterIP
-  port: 8443
+  port: 8080
 
 # see https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.0/html-single/red_hat_jboss_enterprise_application_platform_for_openshift/index#configuring_dns_ping
 pingService:
@@ -37,8 +37,8 @@ maintenancePage:
   resources: {}
 
 admin:
-  username: admin
-  password: admin
+  username:
+  password:
 
 postgres:
   host: sso-patroni
@@ -62,11 +62,11 @@ additionalServerOptions: "-Dkeycloak.profile.feature.authorization=enabled -Djbo
 
 # see https://github.com/keycloak/keycloak-containers/blob/master/server/README.md#setting-up-tlsssl
 tls:
-  enabled: true
+  enabled: false
 
 persistentLog:
   enabled: true
-  size: 2Gi
+  size: 5Gi
   storageClass: netapp-file-standard
   mountPath: /var/log/eap
   annotations: {}
@@ -75,10 +75,10 @@ persistentLog:
 
 resources:
   limits:
-    cpu: 1
+    cpu: 2
     memory: 2Gi
   requests:
-    cpu: 0.8
+    cpu: 200m
     memory: 1Gi
 
 rollingUpdate: {}
@@ -130,7 +130,7 @@ rbac:
   create: true
 
 patroni:
-  replicaCount: 2
+  replicaCount: 3
 
   image:
     repository: ghcr.io/zalando/spilo-15
@@ -148,14 +148,10 @@ patroni:
       password:
 
   persistentVolume:
-    size: 1Gi
+    size: 10Gi
 
   podDisruptionBudget:
-    enabled: false
+    enabled: true
 
-  transportServerClaim:
-    enabled: false
-
-maintenancePage:
-  enabled: false
-  active: false
+tags:
+  patroni-enabled: true

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -1,8 +1,8 @@
-replicaCount: 1
+replicaCount: 2
 
 image:
   repository: ghcr.io/bcgov/sso
-  tag:  24.0.5-build.1
+  tag:  24.0.8-build.1
   pullPolicy: Always
 
 project: sso-keycloak
@@ -19,7 +19,7 @@ networkPolicies:
 
 service:
   type: ClusterIP
-  port: 8080
+  port: 8443
 
 # see https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.0/html-single/red_hat_jboss_enterprise_application_platform_for_openshift/index#configuring_dns_ping
 pingService:
@@ -37,8 +37,8 @@ maintenancePage:
   resources: {}
 
 admin:
-  username:
-  password:
+  username: admin
+  password: admin
 
 postgres:
   host: sso-patroni
@@ -62,11 +62,11 @@ additionalServerOptions: "-Dkeycloak.profile.feature.authorization=enabled -Djbo
 
 # see https://github.com/keycloak/keycloak-containers/blob/master/server/README.md#setting-up-tlsssl
 tls:
-  enabled: false
+  enabled: true
 
 persistentLog:
   enabled: true
-  size: 5Gi
+  size: 2Gi
   storageClass: netapp-file-standard
   mountPath: /var/log/eap
   annotations: {}
@@ -75,10 +75,10 @@ persistentLog:
 
 resources:
   limits:
-    cpu: 2
+    cpu: 1
     memory: 2Gi
   requests:
-    cpu: 200m
+    cpu: 0.8
     memory: 1Gi
 
 rollingUpdate: {}
@@ -130,7 +130,7 @@ rbac:
   create: true
 
 patroni:
-  replicaCount: 3
+  replicaCount: 2
 
   image:
     repository: ghcr.io/zalando/spilo-15
@@ -148,10 +148,14 @@ patroni:
       password:
 
   persistentVolume:
-    size: 10Gi
+    size: 1Gi
 
   podDisruptionBudget:
-    enabled: true
+    enabled: false
 
-tags:
-  patroni-enabled: true
+  transportServerClaim:
+    enabled: false
+
+maintenancePage:
+  enabled: false
+  active: false


### PR DESCRIPTION
Putting this in draft for discussion. It is recommended to use a stateful set instead of deployment, not because of persistant volume bindings but because of orderly pod removal and addition. There is a [good discussion](https://github.com/keycloak/keycloak/discussions/11763) from the base keycloak project which is relevant, but basically the infinispan cache can have issues if many pods restart at once.

This also fixes the log filename issues, since pods have stable (but unique) hostnames they will write to the same file on rollover. e.g. sso-keycloak-0, sso-keycloak-1, sso-keycloak-3 stay the same over rollouts and keep using sso-keycloak-0.log, etc.

While looking into the helm chart I went through some of the existing environment variables to see which were deprecated since the redhat folks mentioned it. 

- Using --optimized: See [here], it shaves 13 seconds off startup but may not be usable since we use a database. I think if we pass in the db type to the build it will be better. But running in c6 this seems to have no impact, the instance is connecting to postgres with optimized passed.

- **X509_CA_BUNDLE**: See [here](https://docs.redhat.com/en-us/documentation/red_hat_build_of_keycloak/22.0/pdf/migration_guide/Red_Hat_build_of_Keycloak-22.0-Migration_Guide-en-US.pdf) (have to search the pdf for it), deprecated now.
- **JGROUPS_PING_PROTOCOL**, **DNS_PING**, **OPENSHIFT_DNS_PING_SERVICE_NAME**, **OPENSHIFT_DNS_PING_SERVICE_PORT**: None of these seem relevant anymore, all cache-configuration variables for 24 can be found [here](https://docs.redhat.com/en/documentation/red_hat_build_of_keycloak/24.0/html-single/server_guide/index#caching-relevant-options)
- **JGROUPS_CLUSTER_PASSWORD**: There do not seem to be references to setting up jgroups encryption this way anymore, so I removed it. I am still exploring replacing cluster communication encryption, there is a guide [here](https://docs.redhat.com/en/documentation/red_hat_build_of_keycloak/24.0/html/server_guide/caching-#caching-securing-cache-communication). Also the above configurations show the environment variables for configuring the key.
- **DB_JNDI**: Deprecated in 22. See [here](https://docs.redhat.com/en-us/documentation/red_hat_build_of_keycloak/22.0/pdf/migration_guide/Red_Hat_build_of_Keycloak-22.0-Migration_Guide-en-US.pdf)
- **TX_DATABASE_PREFIX_MAPPING**, **DB_SERVICE_PREFIX_MAPPING**: These are no longer in the [database options](https://docs.redhat.com/en/documentation/red_hat_build_of_keycloak/24.0/html/server_guide/db-#db-relevant-options) for version 24.